### PR TITLE
feat: Add scroll-to-top button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -83,3 +83,7 @@
         #filter-bar.hidden-bar {
             transform: translateY(-120%);
         }
+        #scroll-to-top-btn {
+            z-index: 40;
+            transition: opacity 0.3s, visibility 0.3s;
+        }

--- a/index.html
+++ b/index.html
@@ -308,6 +308,11 @@
         </div>
     </div>
 
-    
+    <!-- Botón para volver arriba -->
+    <button id="scroll-to-top-btn" class="hidden fixed bottom-5 right-5 bg-violet-600 hover:bg-violet-700 text-white font-bold p-3 rounded-full shadow-lg transition-transform transform hover:scale-110">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
+        </svg>
+    </button>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -3,7 +3,7 @@ import { currentUser, updateAuthUI } from './auth.js';
 import { debounce } from './utils.js';
 import { applyFilters, populateFilters, clearFiltersBtn, searchInput, playersInput, complexityPopover, playersPopover, timePopover } from './filters.js';
 import { renderGames, openGameDetailsModal, gameGrid, loaderContainer, noResultsMessage, errorMessage, rlsTip } from './dom.js';
-import { showModal } from './ui.js';
+import { showModal, initializeScrollToTop } from './ui.js';
 
 // --- GLOBAL STATE ---
 let masterGameList = [];
@@ -393,6 +393,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const sessionData = await supabase.auth.getSession();
     updateAuthUI(sessionData.data.session ? sessionData.data.session.user : null);
     await fetchAllGames();
+    initializeScrollToTop();
 
     // Event listener for Add Game button
     addGameBtn.addEventListener('click', () => {

--- a/js/ui.js
+++ b/js/ui.js
@@ -38,3 +38,24 @@ document.addEventListener('keydown', (e) => {
         showModal(null); // Ocultar todos los modales
     }
 });
+
+// --- SCROLL TO TOP ---
+export const initializeScrollToTop = () => {
+    const scrollToTopBtn = document.getElementById('scroll-to-top-btn');
+    if (!scrollToTopBtn) return;
+
+    window.addEventListener('scroll', () => {
+        if (window.scrollY > 300) {
+            scrollToTopBtn.classList.remove('hidden');
+        } else {
+            scrollToTopBtn.classList.add('hidden');
+        }
+    });
+
+    scrollToTopBtn.addEventListener('click', () => {
+        window.scrollTo({
+            top: 0,
+            behavior: 'smooth'
+        });
+    });
+};


### PR DESCRIPTION
This commit adds a floating 'scroll to top' button to the bottom right of the page. The button appears when the user scrolls down and smoothly scrolls the page back to the top when clicked. This feature is implemented for both mobile and desktop versions.